### PR TITLE
leftover client handling, login and riot client launch separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,13 @@ Tested and working on Windows 7 (Python 3.8), Windows Server 2019 (Python 3.10).
     - Once install is finished you'll be ready to go!
 - Launch the GUI by opening "main.pyw"
 ## Main
-![MainTab](https://i.imgur.com/uSg2ucV.png)
+![MainTab](https://i.imgur.com/BkJELsk.png)
 
-Here you can see the console and track the progress. "Start" button will start checking accounts if settings are properly configured ("Save" button in each tab is only to save for next launch, "Start" will use current settings regardless whether they are saved or not). If there's an issue - an error will be shown in the console.
+Here you can see the console and track the progress. 
+- "Start" - starts checking accounts if settings are properly configured ("Save" button in each tab is only to save for next launch, "Start" will use current settings regardless whether they are saved or not). If there's an issue - an error will be shown in the console.
+- "Stop" - gracefully stops all running checker threads (exporting will be skipped)
+- "Exports folder" - opens export directory if it exists
+- "Erase exports" - erases all export files in the export directory
 
 ## Settings
 ![SettingsTab](https://i.imgur.com/OXvyGit.png)

--- a/clientMain/auth.py
+++ b/clientMain/auth.py
@@ -22,16 +22,12 @@ def authenticate(riotConnection, username, password):
 
 # launches riot client, tries to authenticate, handles authentication errors, accepts eula
 # returns riot client object
-def login(username, password, riotClientPath, lock):
-    riotConnection = RiotConnection(riotClientPath, lock)
-
+def login(username, password, riotConnection):
     authSuccess = authenticate(riotConnection, username, password)
     if not authSuccess == "OK": # something went wrong during login
         raise AuthenticationException(authSuccess["error"].upper(), riotConnection)
 
     acceptEULA(riotConnection)
-
-    return riotConnection
 
 # waits until riot client is ready to launch league client
 # raises an exception if it takes too long


### PR DESCRIPTION
- Now gracefully exists checking threads on GUI getting closed while checking is in progress (no more leftover clients)
- "Stop" button (mimics GUI closing)
- Login function now uses a given client instead of starting a client on its own.