### PR TITLE
Fix and Improve Queue Penalty Check

### DIFF
--- a/accountProcessing/skipping.py
+++ b/accountProcessing/skipping.py
@@ -18,7 +18,9 @@ def checkCanSkip(settings: Dict[str, Any], account: Dict[str, Any]) -> bool:
         
         try:
             accountData, timestamp = readRawExport(account["username"])
-            accountState = accountData["state"]
+            accountState = accountData.get("state")
+            if accountState is None:
+                return False
             age = time.time() - timestamp
 
             if settings[guiKeys.DONT_SKIP_ACCOUNTS_WITH_DATA_ONE_DAY_OLD] and age > 86400:

--- a/accountProcessing/thread.py
+++ b/accountProcessing/thread.py
@@ -1,6 +1,7 @@
 from client.connection.exceptions import ConnectionException
 from client.connection.exceptions import SessionException
 from client.tasks.export import exportRaw
+from client.tasks.exceptions import LobbyException
 from accountProcessing.skipping import checkCanSkip
 from accountProcessing.exceptions import RateLimitedException
 from accountProcessing.exceptions import GracefulExit
@@ -116,7 +117,7 @@ class Worker:
                 
                 logging.error(f"{self.__account['username']} {exception.message}. Waiting before retrying...")
                 self.__rateLimited(rateLimitCount)
-            except (ConnectionException, SessionException, StoreException) as exception: # something went wrong with api
+            except (ConnectionException, SessionException, StoreException, LobbyException) as exception: # something went wrong with api
                 logging.error(f"{self.__account['username']} {exception.message}. Retrying...")
 
                 failCount += 1

--- a/client/tasks/data.py
+++ b/client/tasks/data.py
@@ -199,7 +199,6 @@ def getRank(leagueConnection: LeagueConnection, account: Dict[str, Any]) -> None
 
 def getLowPriorityQueue(leagueConnection: LeagueConnection, account: Dict[str, Any]) -> None:
     removeLeaverBusterNotifications(leagueConnection)
-    leagueConnection.waitForUpdate()
     queueId = 400
 
     if not canQueueUp(leagueConnection, queueId):

--- a/client/tasks/exceptions.py
+++ b/client/tasks/exceptions.py
@@ -2,3 +2,8 @@ class NoAccountDataException(Exception):
     def __init__(self, message):
         self.message = message
         Exception.__init__(self)
+
+class LobbyException(Exception):
+    def __init__(self, message):
+        self.message = message
+        Exception.__init__(self)

--- a/client/tasks/utils.py
+++ b/client/tasks/utils.py
@@ -1,0 +1,26 @@
+from time import sleep
+from client.connection.LeagueConnection import LeagueConnection
+
+
+def removeLeaverBusterNotifications(leagueConnection: LeagueConnection) -> None:
+    notifications = leagueConnection.get("/lol-leaver-buster/v1/notifications").json()
+    for notification in notifications:
+        leagueConnection.delete(f"/lol-leaver-buster/v1/notifications/{notification['id']}")
+
+
+def canQueueUp(leagueConnection: LeagueConnection, queueId: int, timeout: int = 15):
+    eligibility = leagueConnection.post("/lol-lobby/v2/eligibility/party").json()
+    for queueType in eligibility:
+        if queueType["queueId"] == queueId:
+            if queueType["eligible"]:
+                return True
+            elif queueType["restrictions"][0]["restrictionCode"] == "GameVersionMissing":
+                for _ in range(timeout):
+                    sleep(1)
+                    clientState = leagueConnection.get("/lol-patch/v1/products/league_of_legends/state").json()
+                    if clientState.get("action") == "Idle":
+                        sleep(1)
+                        return True
+                return False
+            else:
+                return False

--- a/client/tasks/utils.py
+++ b/client/tasks/utils.py
@@ -1,5 +1,6 @@
 from time import sleep
 from client.connection.LeagueConnection import LeagueConnection
+from client.tasks.exceptions import LobbyException
 
 
 def removeLeaverBusterNotifications(leagueConnection: LeagueConnection) -> None:
@@ -8,19 +9,16 @@ def removeLeaverBusterNotifications(leagueConnection: LeagueConnection) -> None:
         leagueConnection.delete(f"/lol-leaver-buster/v1/notifications/{notification['id']}")
 
 
-def canQueueUp(leagueConnection: LeagueConnection, queueId: int, timeout: int = 15):
+def canQueueUp(leagueConnection: LeagueConnection, queueId: int):
+    leagueConnection.waitForUpdate()
     eligibility = leagueConnection.post("/lol-lobby/v2/eligibility/party").json()
     for queueType in eligibility:
         if queueType["queueId"] == queueId:
             if queueType["eligible"]:
                 return True
             elif queueType["restrictions"][0]["restrictionCode"] == "GameVersionMissing":
-                for _ in range(timeout):
-                    sleep(1)
-                    clientState = leagueConnection.get("/lol-patch/v1/products/league_of_legends/state").json()
-                    if clientState.get("action") == "Idle":
-                        sleep(1)
-                        return True
-                return False
+                raise LobbyException("canQueueUp check failed: GameVersionMissing")
             else:
                 return False
+
+    raise LobbyException(f"canQueueUp check failed: queueId-{queueId} not found")

--- a/templates/single/exampleJson.txt
+++ b/templates/single/exampleJson.txt
@@ -48,5 +48,6 @@
     "previousSeasonFlexDivision": "{previousSeasonFlexDivision}",
     "previousSeasonFlexDivisionDigit": "{previousSeasonFlexDivisionDigit}",
     "lowPriorityQueue": "{lowPriorityQueue}",
-    "lastMatch": "{lastMatch}"
+    "lastMatch": "{lastMatch}",
+    "rankedRestriction": "{rankedRestriction}"
 },


### PR DESCRIPTION
Low priority queue check will now:
- Use draft pick as blind pick no longer exists.
- Be skipped if an account is ineligible to queue up instead of erroring out.
- Delete all leaver buster notifications.

Added a check for ranked restriction which will be run when FULL data checking is enabled and a new export variable: rankedRestriction

Handle the case where an account's raw data is corrupted/modified causing skip check to error out.