### PR TITLE
QoL - Add automatic client cleanup

### DIFF
--- a/GUI/keys.py
+++ b/GUI/keys.py
@@ -6,6 +6,7 @@ ACCOUNT_FILE_DELIMITER = "accountsDelimiter"
 THREAD_COUNT = "threadCount"
 HEADLESS = "headless"
 SKIP_LOW_PRIO_CHECK = "skipLowPrioCheck"
+CLIENT_WATCHER_ENABLED = "clientWatcherEnabled"
 
 # Tasks Tab
 CLAIM_EVENT_REWARDS = "claimEventRewards"

--- a/GUI/layouts.py
+++ b/GUI/layouts.py
@@ -40,6 +40,7 @@ def getSettingsLayout(cwd):
         [sg.Text("Thread Count"), sg.Combo([x for x in range(1,17)], default_value=sg.user_settings_get_entry(guiKeys.THREAD_COUNT, 2), key=guiKeys.THREAD_COUNT)],
         [sg.Checkbox("Run League Client Headless", default=sg.user_settings_get_entry(guiKeys.HEADLESS, True), key=guiKeys.HEADLESS, size=(70,1), font=("Helvetica", 9))],
         [sg.Checkbox("Skip Low Priority Queue Check", default=sg.user_settings_get_entry(guiKeys.SKIP_LOW_PRIO_CHECK, False), key=guiKeys.SKIP_LOW_PRIO_CHECK, size=(70,1), font=("Helvetica", 9))],
+        [sg.Checkbox("Always Run Client Watcher", default=sg.user_settings_get_entry(guiKeys.CLIENT_WATCHER_ENABLED, True), key=guiKeys.CLIENT_WATCHER_ENABLED, size=(70,1), font=("Helvetica", 9))],
         [sg.VPush()],
         [sg.Button("Save", key="saveSettings")],
     ]

--- a/GUI/saving.py
+++ b/GUI/saving.py
@@ -27,6 +27,7 @@ def saveSettings(values: Dict[str, Any]) -> None:
         guiKeys.THREAD_COUNT,
         guiKeys.HEADLESS,
         guiKeys.SKIP_LOW_PRIO_CHECK,
+        guiKeys.CLIENT_WATCHER_ENABLED,
     ]
     save(values, allSettings)
 

--- a/README.md
+++ b/README.md
@@ -30,12 +30,15 @@ The main tab displays the console and tracks the progress. It offers the followi
 - **Exports folder**: Opens the export directory if it exists.
 
 ## **Settings Tab**
-![SettingsTab](https://i.imgur.com/gAFycWL.png)
+![SettingsTab](https://i.imgur.com/2YEppzh.png)
 - **RiotClientServices.exe location**: Path to RiotClientServices.exe on your device. No need to change if using the default installation location.
 - **LeagueClient.exe location**: Path to LeagueClient.exe on your device. No need to change if using the default installation location.
 - **Account file location**: Path to your account file. The account file should contain one account per line, with the username and password separated by the specified delimiter: <br /> ![ExampleAccountFile](https://i.imgur.com/k9A8R4H.png)
 - **Account file delimiter**: Select the delimiter used in your account file.
 - **Thread count**: Number of threads to use for account checking. When using 1 thread, the Riot/League client will be able to update, while in other cases, patching is disabled.
+- **Run League Client Headless**: When enabled League clients will be ran without UI.
+- **Skip Low Priority Queue Check**: When enabled skips check for low priority penalty information
+- **Always Run Client Watcher**: Enables Riot/League client process cleanup when running with more than 1 thread (it is always enabled when running with 1 thread and cannot be disabled). Will terminate all client processes that are not used by the checker periodically.
 
 ## **Tasks Tab**
 ![TasksTab](https://i.imgur.com/xAymURs.png)

--- a/accountProcessing/utils/ClientWatcherProcess.py
+++ b/accountProcessing/utils/ClientWatcherProcess.py
@@ -1,0 +1,39 @@
+from typing import List
+from multiprocessing import Lock, Process
+import psutil
+import logging
+from time import sleep
+import config
+
+
+class ClientWatcherProcess(Process):
+
+    def __init__(self, portsInUse: List, lock: Lock):
+        super().__init__()
+        self.__portsInUse = portsInUse
+        self.__lock = lock
+
+    def run(self):
+        while True:
+            for process in psutil.process_iter(['pid', 'name', 'cmdline']):
+                if process.info['name'] == 'RiotClientServices.exe' or process.info['name'] == 'LeagueClient.exe':
+                    try:
+                        cmdLineArgs = process.info['cmdline']
+                        if self.__canTerminate(cmdLineArgs):
+                            logging.debug(f"Terminating process {process.info['pid']} ({cmdLineArgs[0]})")
+                            psutil.Process(process.info['pid']).terminate()
+                    except Exception as e:
+                        logging.debug(f"Error terminating a process: {e}")
+
+            sleep(config.CLIENT_WATCHER_CHECK_COOLDOWN)
+
+    def __canTerminate(self, cmdLineArgs):
+        for arg in cmdLineArgs:
+            if arg.startswith("--app-port"):
+                _, value = arg.split("=")
+                with self.__lock:
+                    if int(value) in self.__portsInUse:
+                        return False
+                return True
+
+        return True

--- a/accountProcessing/utils/ClientWatcherProcess.py
+++ b/accountProcessing/utils/ClientWatcherProcess.py
@@ -7,6 +7,7 @@ import config
 
 
 class ClientWatcherProcess(Process):
+    __PROCESSES_TO_KILL = {"RiotClientServices.exe", "LeagueClient.exe"}
 
     def __init__(self, portsInUse: List, lock: Lock):
         super().__init__()
@@ -15,13 +16,13 @@ class ClientWatcherProcess(Process):
 
     def run(self):
         while True:
-            for process in psutil.process_iter(['pid', 'name', 'cmdline']):
-                if process.info['name'] == 'RiotClientServices.exe' or process.info['name'] == 'LeagueClient.exe':
+            for process in psutil.process_iter(["pid", "name", "cmdline"]):
+                if process.info["name"] in self.__PROCESSES_TO_KILL:
                     try:
-                        cmdLineArgs = process.info['cmdline']
+                        cmdLineArgs = process.info["cmdline"]
                         if self.__canTerminate(cmdLineArgs):
                             logging.debug(f"Terminating process {process.info['pid']} ({cmdLineArgs[0]})")
-                            psutil.Process(process.info['pid']).terminate()
+                            psutil.Process(process.info["pid"]).terminate()
                     except Exception as e:
                         logging.debug(f"Error terminating a process: {e}")
 

--- a/accountProcessing/utils/PortHandler.py
+++ b/accountProcessing/utils/PortHandler.py
@@ -1,0 +1,21 @@
+from typing import List, Deque
+from multiprocessing import Lock
+
+
+class PortHandler:
+
+    def __init__(self, ports: Deque, portsInUse: List, lock: Lock) -> None:
+        self.__lock = lock
+        self.__ports = ports
+        self.__portsInUse = portsInUse
+
+    def getFreePort(self) -> int:
+        with self.__lock:
+            freePort = self.__ports.pop()
+            self.__portsInUse.append(freePort)
+            return freePort
+
+    def returnPort(self, port: int) -> None:
+        with self.__lock:
+            self.__ports.append(port)
+            self.__portsInUse.remove(port)

--- a/accountProcessing/utils/utils.py
+++ b/accountProcessing/utils/utils.py
@@ -1,0 +1,19 @@
+from contextlib import contextmanager
+from typing import List
+from multiprocessing import Lock
+from accountProcessing.utils.ClientWatcherProcess import ClientWatcherProcess
+
+
+@contextmanager
+def conditionalClientWatcher(portsInUse: List, lock: Lock, runWatcher: bool) -> None:
+    watcher = None
+    if runWatcher:
+        watcher = ClientWatcherProcess(portsInUse, lock)
+        watcher.start()
+
+    try:
+        yield
+    finally:
+        if watcher is not None:
+            watcher.terminate()
+            watcher.join()

--- a/config.py
+++ b/config.py
@@ -17,12 +17,12 @@ FAILED_ACCOUNT_PATH = "failedAccounts.txt" # in export folder
 UNFINISHED_ACCOUNT_PATH = "uncheckedAccounts.txt"
 
 # riot client
-RIOT_CLIENT_LAUNCH_COOLDOWN = 10
+RIOT_CLIENT_LAUNCH_COOLDOWN = 12
 RIOT_CLIENT_LOADING_RETRY_COUNT = 3
 RIOT_CLIENT_LOADING_RETRY_COOLDOWN = 3
 
 # league client
-LEAGUE_CLIENT_LAUNCH_COOLDOWN = 10
+LEAGUE_CLIENT_LAUNCH_COOLDOWN = 12
 
 # failure handling
 LAUNCH_COOLDOWN_ON_INVALID_CREDENTIALS = 30
@@ -35,3 +35,6 @@ LOL_STORE_REQUEST_COOLDOWN = 30
 
 # login captcha
 LOGIN_URL = "https://authenticate.riotgames.com/api/v1/login"
+
+# client watcher
+CLIENT_WATCHER_CHECK_COOLDOWN = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests==2.31.0
 capmonstercloudclient==1.3.2
 capsolver==1.0.7
 pywin32==306
+psutil==5.9.5


### PR DESCRIPTION
Add automatic terminating of Riot/League client processes that aren't in use by the checker when running using 1 thread with an option to enable it when running with multiple threads.